### PR TITLE
Switch to using typed memoryview and python object input

### DIFF
--- a/find_closest_element.pyx
+++ b/find_closest_element.pyx
@@ -3,6 +3,22 @@ cimport numpy as c_np
 cimport cython_declaration_module
 
 def find_closest_element_wrapper(double[:] input_data, key):
+    """
+    Find the index into the array ``input_data`` that gives the value closest
+    to ``key``.
+
+    Parameters
+    ----------
+    input_data : 1D array with dtype double
+        The input array to search through.
+    key : float
+        The value to find the closest ``input_data`` element of.
+
+    Returns
+    -------
+    idx : int
+        The index into ``input_data`` of the closest element to ``key``.
+    """
     cdef int result
     result = cython_declaration_module.find_closest_element_in_c(&input_data[0], len(input_data), key)
     return result

--- a/find_closest_element.pyx
+++ b/find_closest_element.pyx
@@ -2,7 +2,7 @@ cimport numpy as c_np
 
 cimport cython_declaration_module
 
-def find_closest_element_wrapper(c_np.ndarray[c_np.float64_t, ndim=1] input_data, key):
+def find_closest_element_wrapper(double[:] input_data, key):
     cdef int result
     result = cython_declaration_module.find_closest_element_in_c(&input_data[0], len(input_data), key)
     return result

--- a/find_closest_element.pyx
+++ b/find_closest_element.pyx
@@ -1,5 +1,3 @@
-cimport numpy as c_np 
-
 cimport cython_declaration_module
 
 def find_closest_element_wrapper(double[:] input_data, key):

--- a/find_closest_element.pyx
+++ b/find_closest_element.pyx
@@ -1,13 +1,15 @@
+import numpy as np
+
 cimport cython_declaration_module
 
-def find_closest_element_wrapper(double[:] input_data, key):
+def find_closest_element_wrapper(input_data, key):
     """
     Find the index into the array ``input_data`` that gives the value closest
     to ``key``.
 
     Parameters
     ----------
-    input_data : 1D array with dtype double
+    input_data : array-like
         The input array to search through.
     key : float
         The value to find the closest ``input_data`` element of.
@@ -18,5 +20,9 @@ def find_closest_element_wrapper(double[:] input_data, key):
         The index into ``input_data`` of the closest element to ``key``.
     """
     cdef int result
-    result = cython_declaration_module.find_closest_element_in_c(&input_data[0], len(input_data), key)
+    cdef double [:] c_input
+
+    # this will only make a copy if the input dtype is not already a double
+    c_input = np.array(input_data, dtype=np.double, copy=False)
+    result = cython_declaration_module.find_closest_element_in_c(&c_input[0], len(input_data), key)
     return result


### PR DESCRIPTION
This adds a couple tweaks to `find_closest_element.pyx` that I think make it a bit clearer:
- Change the input to be a typed memoryview instead of the "old-style" numpy wrapper
- Add a docstring (to demonstrate that you can)
- (More controversial because it's potentially less "minimal") Change to having the first input be a python object that then gets converted into a memoryview _inside_ the function.  If you don't like this, @aphearin, I can easily roll back that one commit.

The advantage of the last one is that the old way, something like `find_closest_element_wrapper([1.,2.3,0.1], 0)` will fail, b/c it's not an actual array.  Similarly, `find_closest_element_wrapper(np.array([1,2,3]), 0)` will also fail, because it's not a dtype of `double`.  This way of doing it does the conversion to a double-array on-the-fly allowing more flexible input.
